### PR TITLE
Allow providing gitlab token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This is a [pre-commit hook](https://pre-commit.com/). Uses the `/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file. By default, sends your configuration to https://gitlab.com, but this can be overridden, see below.
 
+## Usage
+
+GitLab Lint API now [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/issues/321290).
+1. [Create Access Token](https://gitlab.com/-/profile/personal_access_tokens) with `api` scope.
+2. Set access token value as `GITLAB_TOKEN` environment variable
+
+**Warning** Please note the token should not be shared and if leaked can cause significant harm.
+
 An example `.pre-commit-config.yaml`:
 
 ```yaml

--- a/gitlabci_lint/__init__.py
+++ b/gitlabci_lint/__init__.py
@@ -1,19 +1,22 @@
+import argparse
 import json
 import os
-import sys
 
-try:
-    from urllib.request import Request, urlopen
-    from urllib.error import URLError
-    from urllib.parse import urljoin
-except ImportError:
-    from urllib2 import Request, urlopen, URLError
-    from urlparse import urljoin
+from urllib.error import URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
 
 
-def main(base_url="https://gitlab.com/"):
-    if len(sys.argv) > 1:
-        base_url = sys.argv[1]
+parser = argparse.ArgumentParser()
+parser.add_argument("base_url", nargs="?", default="https://gitlab.com/")
+parser.add_argument("--token", default=os.getenv("GITLAB_TOKEN"))
+
+
+def main(argv=None):
+    args = parser.parse_args(argv)
+    base_url = args.base_url
+    token = args.token
+
     rv = 0
     try:
         with open(".gitlab-ci.yml", "r") as f:
@@ -28,7 +31,6 @@ def main(base_url="https://gitlab.com/"):
             "Content-Type": "application/json",
             "Content-Length": len(data),
         }
-        token = os.getenv("GITLAB_TOKEN")
         if token:
             headers["PRIVATE-TOKEN"] = token
             msg_using_linter += " with token " + len(token) * "*"

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,7 @@ setup(
     name="pre-commit-gitlabci-lint",
     packages=["gitlabci_lint"],
     entry_points={"console_scripts": ["gitlabci-lint = gitlabci_lint:main"]},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
 )


### PR DESCRIPTION
Allows work around #3 by providing gitlab personal access token. Not the best solution, but its a start.