### PR TITLE
Get ci config path from gitlab api

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501, W503

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv
+.vscode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+default_language_version:
+  python: python3.8
+minimum_pre_commit_version: 2.19.0
+repos:
+- repo: https://github.com/commitizen-tools/commitizen
+  rev: v2.37.0
+  hooks:
+  - id: commitizen
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0  # Use the ref you want to point at
+  hooks:
+    - id: trailing-whitespace
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: forbid-submodules
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.4.1
+  hooks:
+    - id: forbid-tabs
+    - id: remove-tabs
+      args: [--whitespaces-count, '4']  # defaults to: 4
+- repo: https://github.com/psf/black
+  rev: 22.12.0
+  hooks:
+  - id: black
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.0.0
+  hooks:
+  - id: flake8
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+  - id: codespell
+default_install_hook_types:
+- commit-msg
+- pre-push
+- post-checkout
+- pre-commit

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ GitLab Lint API [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/
 
 **Warning** Please note the token should not be shared and if leaked can cause significant harm.
 
+With Gitlab version 15.7 onwards, the ci linter api has changed and requires the project id (see [Validate a project's CI configuration](https://docs.gitlab.com/ee/api/lint.html#validate-a-projects-ci-configuration)).
+Please specify the full linter url in the args parameter containing the correct project id of the hook (replace ':id' with your project id in the example below).
+
 An example `.pre-commit-config.yaml`:
 
 ```yaml
@@ -19,5 +22,6 @@ repos:
     rev: 1.0
     hooks:
       - id: gitlabci-lint
-      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id/ci/lint"]
-
+      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id/ci/lint"] # for gitlab version > 15.7
+      # args: ["https://custom.gitlab.host.com/api/v4/ci/lint"] # for gitlab version < 15.7
+```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # pre-commit-gitlabci-lint
 
-This is a [pre-commit hook](https://pre-commit.com/). Uses the `https://gitlab.com/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file, but this can be overridden, see below.
+This is a [pre-commit hook](https://pre-commit.com/). It uses the `https://gitlab.com/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file, but the api v4 url can be adjusted (see below for an example).
 
 ## Usage
 
 GitLab Lint API [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/issues/321290).
+
 1. [Create Access Token](https://gitlab.com/-/profile/personal_access_tokens) with `api` scope.
-2. Set access token value as `GITLAB_TOKEN` environment variable
+2.1 Set access token value as `GITLAB_TOKEN` environment variable
+2.2 Or provide the access token via argument (see example below)
 
 **Warning** Please note the token should not be shared and if leaked can cause significant harm.
 
@@ -22,6 +24,7 @@ repos:
     rev: 1.0
     hooks:
       - id: gitlabci-lint
-      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id/ci/lint"] # for gitlab version > 15.7
-      # args: ["https://custom.gitlab.host.com/api/v4/ci/lint"] # for gitlab version < 15.7
+      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id"] # for gitlab version > 15.7
+      # args: ["https://custom.gitlab.host.com/api/v4"] # for gitlab version < 15.7
+      # args: [--token, 'Your_Gitlab_Access_Token_Value']
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # pre-commit-gitlabci-lint
 
-This is a [pre-commit hook](https://pre-commit.com/). Uses the `/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file. By default, sends your configuration to https://gitlab.com, but this can be overridden, see below.
+This is a [pre-commit hook](https://pre-commit.com/). Uses the `https://gitlab.com/api/v4/ci/lint` lint endpoint to validate the contents of your `.gitlab-ci.yml` file, but this can be overridden, see below.
 
 ## Usage
 
-GitLab Lint API now [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/issues/321290).
+GitLab Lint API [requires authorization](https://gitlab.com/gitlab-org/gitlab/-/issues/321290).
 1. [Create Access Token](https://gitlab.com/-/profile/personal_access_tokens) with `api` scope.
 2. Set access token value as `GITLAB_TOKEN` environment variable
 
@@ -15,10 +15,9 @@ An example `.pre-commit-config.yaml`:
 ```yaml
 ---
 repos:
-  - repo: https://github.com/kadrach/pre-commit-gitlabci-lint
-    rev: master
+  - repo: https://github.com/frerksaxen/pre-commit-gitlabci-lint
+    rev: 1.0
     hooks:
       - id: gitlabci-lint
-      # args: ["https://custom.gitlab.host.com"]
-```
+      # args: ["https://custom.gitlab.host.com/api/v4/projects/:id/ci/lint"]
 

--- a/gitlabci_lint/__init__.py
+++ b/gitlabci_lint/__init__.py
@@ -8,9 +8,10 @@ from urllib.request import Request, urlopen
 
 
 token_env_key = "GITLAB_TOKEN"
+default_ci_config_path = ".gitlab-ci.yml"
 
 parser = argparse.ArgumentParser()
-parser.add_argument("url", nargs="?", default="https://gitlab.com/api/v4/ci/lint")
+parser.add_argument("url", nargs="?", default="https://gitlab.com/api/v4")
 parser.add_argument(
     "--token",
     default=os.getenv(token_env_key),
@@ -30,70 +31,87 @@ def print_messages(messages: List[str]):
     print("=======")
 
 
+def urlerr(err, token):
+    print("Error connecting to Gitlab: " + str(err))
+    if not token and isinstance(err, urllib.error.HTTPError) and err.code == 401:
+        print(
+            "The lint endpoint requires authentication."
+            "Please set {} environment variable".format(token_env_key)
+        )
+
+
 def main(argv=None):
     args = parser.parse_args(argv)
     url = args.url
+    if url.endswith("/"):
+        url = url.rstrip("/")
+    lint_ext = "/ci/lint"
+    if url.endswith(lint_ext):
+        url = url.rstrip(lint_ext)
     token = args.token
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if token:
+        headers["PRIVATE-TOKEN"] = token
 
     rv = 0
     try:
-        with open(".gitlab-ci.yml", "r") as f:
+        response = urlopen(Request(url, headers=headers))
+        project_info = json.loads(response.read())
+        if "ci_config_path" in project_info and project_info["ci_config_path"]:
+            ci_config_path = project_info["ci_config_path"]
+        else:
+            # Use the default path for the gitlab-ci.yml file
+            ci_config_path = default_ci_config_path
+    except urllib.error.URLError:
+        ci_config_path = default_ci_config_path
+
+    try:
+        with open(ci_config_path, "r") as f:
             data = json.dumps({"content": f.read()})
     except (FileNotFoundError, PermissionError):
-        print("Cannot open .gitlab-ci.yml")
-        rv = 1
-    else:
-        # url = urljoin(base_url, "/api/v4/ci/lint")
-        msg_using_linter = "Using linter: " + url
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": len(data),
-        }
-        if token:
-            headers["PRIVATE-TOKEN"] = token
-            msg_using_linter += " with token " + len(token) * "*"
-        print(msg_using_linter)
-        try:
-            request = Request(
-                url,
-                data.encode("utf-8"),
-                headers=headers,
-            )
-            response = urlopen(request)
-            lint_output = json.loads(response.read())
+        print(f"Cannot open {ci_config_path}")
+        return 11
 
-            if "status" in lint_output:
-                # Gitlab version < 15.7
-                if not lint_output["status"] == "valid":
-                    print_messages(lint_output["errors"])
-                    rv = 1
-                elif lint_output["warnings"]:
-                    print_messages(lint_output["warnings"])
-            elif "valid" in lint_output:
-                # Gitlab version > 15.7
-                if not lint_output["valid"]:
-                    print_messages(lint_output["errors"])
-                    rv = 1
-                elif lint_output["warnings"]:
-                    print_messages(lint_output["warnings"])
-            else:
-                # Gitlab changed its output again?
-                print(
-                    "Unknown gitlab response. Did gitlab update the ci linter response again?"
-                )
+    url += lint_ext
+    headers["Content-Length"] = len(data)
+    msg_using_linter = "Using linter: " + url
+    if token:
+        msg_using_linter += " with token " + len(token) * "*"
+    print(msg_using_linter)
+    try:
+        request = Request(
+            url,
+            data.encode("utf-8"),
+            headers=headers,
+        )
+        response = urlopen(request)
+        lint_output = json.loads(response.read())
+
+        if "status" in lint_output:
+            # Gitlab version < 15.7
+            if not lint_output["status"] == "valid":
+                print_messages(lint_output["errors"])
                 rv = 1
-        except urllib.error.URLError as exc:
-            print("Error connecting to Gitlab: " + str(exc))
-            if (
-                not token
-                and isinstance(exc, urllib.error.HTTPError)
-                and exc.code == 401
-            ):
-                print(
-                    "The lint endpoint requires authentication."
-                    "Please set {} environment variable".format(token_env_key)
-                )
-            rv = 1
+            elif lint_output["warnings"]:
+                print_messages(lint_output["warnings"])
+        elif "valid" in lint_output:
+            # Gitlab version > 15.7
+            if not lint_output["valid"]:
+                print_messages(lint_output["errors"])
+                rv = 2
+            elif lint_output["warnings"]:
+                print_messages(lint_output["warnings"])
+        else:
+            # Gitlab changed its output again?
+            print(
+                "Unknown gitlab response. Did gitlab update the ci linter response again?"
+            )
+            rv = 3
+    except urllib.error.URLError as err:
+        urlerr(err, token)
+        return 12
     return rv
 
 

--- a/gitlabci_lint/__init__.py
+++ b/gitlabci_lint/__init__.py
@@ -10,7 +10,7 @@ from urllib.request import Request, urlopen
 token_env_key = "GITLAB_TOKEN"
 
 parser = argparse.ArgumentParser()
-parser.add_argument("base_url", nargs="?", default="https://gitlab.com/")
+parser.add_argument("url", nargs="?", default="https://gitlab.com/api/v4/ci/lint")
 parser.add_argument(
     "--token",
     default=os.getenv(token_env_key),
@@ -25,7 +25,7 @@ parser.add_argument(
 
 def main(argv=None):
     args = parser.parse_args(argv)
-    base_url = args.base_url
+    url = args.url
     token = args.token
 
     rv = 0
@@ -36,7 +36,7 @@ def main(argv=None):
         print("Cannot open .gitlab-ci.yml")
         rv = 1
     else:
-        url = urljoin(base_url, "/api/v4/ci/lint")
+        # url = urljoin(base_url, "/api/v4/ci/lint")
         msg_using_linter = "Using linter: " + url
         headers = {
             "Content-Type": "application/json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.commitizen]
+  annotated_tag = true
+  bump_message = "bump: release $current_version \u2192 $new_version [skip-ci]"
+  name = "cz_conventional_commits"
+  tag_format = "$version"
+  version = "0.0.0"
+  version_files = [
+    "setup.py:version",
+  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
   bump_message = "bump: release $current_version \u2192 $new_version [skip-ci]"
   name = "cz_conventional_commits"
   tag_format = "$version"
-  version = "0.0.0"
+  version = "1.0.0"
   version_files = [
     "setup.py:version",
   ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="pre-commit-gitlabci-lint",
-    version="0.0.0",
+    version="1.0.0",
     packages=["gitlabci_lint"],
     entry_points={"console_scripts": ["gitlabci-lint = gitlabci_lint:main"]},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 
 setup(
     name="pre-commit-gitlabci-lint",
+    version="0.0.0",
     packages=["gitlabci_lint"],
     entry_points={"console_scripts": ["gitlabci-lint = gitlabci_lint:main"]},
     classifiers=[


### PR DESCRIPTION
Usually, the default ci config path is used (.\gitlab-ci.yml). However, you can specify your own config path within your gitlab project settings. This pull request will read the ci config path from the api before it proceeds calling the linter on that path.